### PR TITLE
propogate exit code out of the main process

### DIFF
--- a/runTestWithIDs.js
+++ b/runTestWithIDs.js
@@ -84,9 +84,10 @@ function test(collection, environment) {
   }
 
   // Optional Callback function which will be executed once Newman is done executing all its tasks.
-  Newman.execute(collection, newmanOptions, quit());
+  Newman.execute(collection, newmanOptions, newman_finished_callback);
 }
 
-function quit() {
-  console.log('quited');
+function newman_finished_callback(exitCode) {
+  console.log('Newman finished with code '+exitCode);
+  process.exit(exitCode)
 }

--- a/runTestWithIDs.js
+++ b/runTestWithIDs.js
@@ -75,7 +75,7 @@ function test(collection, environment) {
     insecure: false, //Disable strict ssl
     asLibrary: true, // this makes sure the exit code is returned as an argument to the callback function
     stopOnError: false, //Stops the runner when a test case fails
-    exitCode: false, //Continue running tests even after a failure, but exit with code=1
+    exitCode: true, //Continue running tests even after a failure, but exit with code=1
     //noSummary: true, //Does not show the summary for each iteration
     //noColor: false, //Disable colored output
     //noTestSymbols: false, //Disable symbols in test output and use PASS|FAIL instead


### PR DESCRIPTION
If you're running in a CI, you normally need to get the exit code out, I've just changed it to print the exit code at the end and then quit the process with that code.
